### PR TITLE
refactor: 提取 datetime_utils 中的共享 since_epoch() 辅助函数

### DIFF
--- a/src/common/datetime_utils.rs
+++ b/src/common/datetime_utils.rs
@@ -1,36 +1,28 @@
 use chrono::{DateTime, FixedOffset, Local, Offset, Utc};
 use std::time::SystemTime;
 
-pub fn now_millis() -> u64 {
-    use std::time::SystemTime;
+/// Returns the duration since UNIX_EPOCH. Panics only if system clock is before epoch.
+#[inline]
+fn since_epoch() -> std::time::Duration {
     SystemTime::now()
         .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as u64
+        .expect("system clock is before UNIX epoch")
+}
+
+pub fn now_millis() -> u64 {
+    since_epoch().as_millis() as u64
 }
 
 pub fn now_millis_i64() -> i64 {
-    use std::time::SystemTime;
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_millis() as i64
+    since_epoch().as_millis() as i64
 }
 
 pub fn now_second_i32() -> i32 {
-    use std::time::SystemTime;
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as i32
+    since_epoch().as_secs() as i32
 }
 
 pub fn now_second_u32() -> u32 {
-    use std::time::SystemTime;
-    SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as u32
+    since_epoch().as_secs() as u32
 }
 
 const DATETIME_TIMESTAMP_FMT: &str = "%Y-%m-%dT%H:%M:%S%.3f%:z";


### PR DESCRIPTION
- 移除 4 处冗余的内部 `use std::time::SystemTime` 导入
- 将重复的 `SystemTime::now().duration_since(UNIX_EPOCH).unwrap()` 提取为 `since_epoch()`
- 用 `expect` 替换裸 `unwrap`，提供更好的 panic 诊断信息