### PR TITLE
fix: get_string_body 用 lossy 回退替换 unwrap 防止 panic

### DIFF
--- a/src/common/http_utils.rs
+++ b/src/common/http_utils.rs
@@ -19,7 +19,9 @@ impl ResponseWrap {
     }
 
     pub fn get_string_body(&self) -> String {
-        String::from_utf8(self.body.clone()).unwrap()
+        String::from_utf8(self.body.clone()).unwrap_or_else(|e| {
+            String::from_utf8_lossy(e.as_bytes()).into_owned()
+        })
     }
 
     pub fn get_map_headers(&self) -> HashMap<String, String> {


### PR DESCRIPTION
如果响应体包含无效 UTF-8 字节，原来的代码会 panic。现在回退到 lossy 转换，与已有的 `get_lossy_string_body` 方法行为一致。