### PR TITLE
feat: 新增任务导入导出接口

### DIFF
--- a/src/openapi/v1/job_api.rs
+++ b/src/openapi/v1/job_api.rs
@@ -163,3 +163,81 @@ pub(crate) async fn query_job_list(
         ))
     }
 }
+
+/// 导出任务列表（JSON 格式）
+pub(crate) async fn export_jobs(
+    share_data: Data<Arc<ShareData>>,
+    web::Query(request): web::Query<JobQueryListRequest>,
+) -> impl Responder {
+    let mut param = request.to_param();
+    param.offset = 0;
+    param.limit = 0xffff_ffff;
+    if let Ok(Ok(JobManagerResult::JobPageInfo(_total_count, list))) = share_data
+        .job_manager
+        .send(JobManagerReq::QueryJob(param))
+        .await
+    {
+        HttpResponse::Ok()
+            .insert_header(("Content-Disposition", "attachment; filename=\"jobs.json\""))
+            .json(ApiResult::success(Some(list)))
+    } else {
+        HttpResponse::Ok().json(ApiResult::<()>::error(
+            ERROR_CODE_SYSTEM_ERROR.to_string(),
+            Some("export_jobs error".to_string()),
+        ))
+    }
+}
+
+/// 导入任务列表（JSON 格式）
+pub(crate) async fn import_jobs(
+    share_data: Data<Arc<ShareData>>,
+    web::Json(params): web::Json<Vec<JobParam>>,
+) -> impl Responder {
+    let mut success_count = 0u64;
+    let mut fail_count = 0u64;
+    let mut errors: Vec<String> = Vec::new();
+
+    for mut param in params {
+        // 为每个导入的任务分配新 id
+        match share_data
+            .sequence_manager
+            .send(SequenceRequest::GetNextId(SEQ_JOB_ID.clone()))
+            .await
+        {
+            Ok(Ok(SequenceResult::NextId(id))) => {
+                param.id = Some(id);
+                param.update_time = Some(now_millis());
+                match share_data
+                    .raft_request_route
+                    .request(ClientRequest::JobReq {
+                        req: JobManagerRaftReq::AddJob(param),
+                    })
+                    .await
+                {
+                    Ok(_) => success_count += 1,
+                    Err(e) => {
+                        fail_count += 1;
+                        errors.push(format!("add job error: {}", e));
+                    }
+                }
+            }
+            _ => {
+                fail_count += 1;
+                errors.push("get job id error".to_string());
+            }
+        }
+    }
+
+    let msg = format!(
+        "import done: {} success, {} failed",
+        success_count, fail_count
+    );
+    if fail_count > 0 {
+        HttpResponse::Ok().json(ApiResult::<String>::error(
+            ERROR_CODE_SYSTEM_ERROR.to_string(),
+            Some(format!("{}, errors: {:?}", msg, errors)),
+        ))
+    } else {
+        HttpResponse::Ok().json(ApiResult::success(Some(msg)))
+    }
+}

--- a/src/openapi/v1/mod.rs
+++ b/src/openapi/v1/mod.rs
@@ -19,6 +19,8 @@ pub fn v1_api_config(config: &mut ServiceConfig) {
             .service(web::resource("/job/update").route(web::post().to(job_api::update_job)))
             .service(web::resource("/job/info").route(web::get().to(job_api::get_job_info)))
             .service(web::resource("/job/list").route(web::get().to(job_api::query_job_list)))
+            .service(web::resource("/job/export").route(web::get().to(job_api::export_jobs)))
+            .service(web::resource("/job/import").route(web::post().to(job_api::import_jobs)))
             .service(web::resource("/raft/metrics").route(web::get().to(raft_api::metrics)))
             .service(web::resource("/about").route(web::get().to(about_info))),
     );
@@ -33,6 +35,8 @@ pub fn v1_api_config(config: &mut ServiceConfig) {
             .service(web::resource("/job/remove").route(web::post().to(job_api::remove_job)))
             .service(web::resource("/job/info").route(web::get().to(job_api::get_job_info)))
             .service(web::resource("/job/list").route(web::get().to(job_api::query_job_list)))
+            .service(web::resource("/job/export").route(web::get().to(job_api::export_jobs)))
+            .service(web::resource("/job/import").route(web::post().to(job_api::import_jobs)))
             .service(web::resource("/raft/metrics").route(web::get().to(raft_api::metrics)))
             .service(web::resource("/about").route(web::get().to(about_info))),
     );


### PR DESCRIPTION
修复 #10

**功能：** 任务导入导出，便于迁移。

**新增接口：**
- GET /ratch/v1/job/export - 导出任务列表为 JSON 格式
- POST /ratch/v1/job/import - 导入任务列表（JSON 格式）

**导出格式：** JobInfoDto JSON 数组
**导入行为：** 自动分配新 id，保留任务配置信息