### PR TITLE
feat: 实现 ConsistentHash 一致性哈希路由策略

### DIFF
--- a/src/task/model/app_instance.rs
+++ b/src/task/model/app_instance.rs
@@ -2,6 +2,7 @@ use crate::app::model::AppKey;
 use crate::common::hash_utils::get_hash_value;
 use crate::job::model::enum_type::RouterStrategy;
 use rand::prelude::SliceRandom;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -10,6 +11,49 @@ pub enum InstanceAddrSelectResult {
     Selected(Arc<String>),
     ALL(Arc<Vec<Arc<String>>>),
     Empty,
+}
+
+/// 一致性哈希环的虚拟节点数
+const CONSISTENT_HASH_VIRTUAL_NODES: u32 = 160;
+
+/// 一致性哈希环，使用虚拟节点实现均匀分布
+#[derive(Clone, Debug)]
+pub struct ConsistentHashRing {
+    ring: BTreeMap<u64, Arc<String>>,
+}
+
+impl ConsistentHashRing {
+    pub fn new() -> Self {
+        ConsistentHashRing {
+            ring: BTreeMap::new(),
+        }
+    }
+
+    pub fn build(instance_keys: &[Arc<String>]) -> Self {
+        let mut ring = BTreeMap::new();
+        for key in instance_keys {
+            for i in 0..CONSISTENT_HASH_VIRTUAL_NODES {
+                let virtual_key = format!("{}#{}", key, i);
+                let hash = get_hash_value(&virtual_key);
+                ring.insert(hash, key.clone());
+            }
+        }
+        ConsistentHashRing { ring }
+    }
+
+    /// 根据 job_id 的哈希值在环上顺时针查找最近的节点
+    pub fn get_instance(&self, job_id: u64) -> Option<Arc<String>> {
+        if self.ring.is_empty() {
+            return None;
+        }
+        let hash = get_hash_value(&job_id);
+        // 顺时针查找第一个大于等于 hash 的节点，找不到则绕回环首
+        self.ring
+            .range(hash..)
+            .next()
+            .or_else(|| self.ring.iter().next())
+            .map(|(_, v)| v.clone())
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -35,6 +79,7 @@ pub struct AppInstanceStateGroup {
     pub instance_map: HashMap<Arc<String>, AppInstanceState>,
     pub instance_keys: Arc<Vec<Arc<String>>>,
     pub round_robin_index: usize,
+    pub hash_ring: ConsistentHashRing,
 }
 
 impl AppInstanceStateGroup {
@@ -44,6 +89,7 @@ impl AppInstanceStateGroup {
             instance_map: HashMap::new(),
             instance_keys: Arc::new(Vec::new()),
             round_robin_index: 0,
+            hash_ring: ConsistentHashRing::new(),
         }
     }
 
@@ -51,6 +97,11 @@ impl AppInstanceStateGroup {
         self.round_robin_index = 0;
         self.instance_map = HashMap::new();
         self.instance_keys = Arc::new(Vec::new());
+        self.hash_ring = ConsistentHashRing::new();
+    }
+
+    fn rebuild_hash_ring(&mut self) {
+        self.hash_ring = ConsistentHashRing::build(&self.instance_keys);
     }
 
     pub fn set_instance_list(&mut self, instance_list: Vec<Arc<String>>) {
@@ -66,6 +117,7 @@ impl AppInstanceStateGroup {
         let instance = AppInstanceState::new(key.clone());
         self.instance_map.insert(key.clone(), instance);
         self.instance_keys = Arc::new(self.instance_map.keys().map(|k| k.clone()).collect());
+        self.rebuild_hash_ring();
     }
 
     pub fn remove_instance(&mut self, key: Arc<String>) {
@@ -74,6 +126,7 @@ impl AppInstanceStateGroup {
         }
         self.instance_map.remove(&key);
         self.instance_keys = Arc::new(self.instance_map.keys().map(|k| k.clone()).collect());
+        self.rebuild_hash_ring();
     }
 
     pub fn select_instance(
@@ -104,9 +157,11 @@ impl AppInstanceStateGroup {
                 InstanceAddrSelectResult::Selected(selected.clone())
             }
             RouterStrategy::ConsistentHash => {
-                let hash = get_hash_value(&job_id) as usize;
-                let selected = self.instance_keys[hash % self.instance_keys.len()].clone();
-                InstanceAddrSelectResult::Selected(selected)
+                if let Some(selected) = self.hash_ring.get_instance(job_id) {
+                    InstanceAddrSelectResult::Selected(selected)
+                } else {
+                    InstanceAddrSelectResult::Empty
+                }
             }
             RouterStrategy::ShardingBroadcast => {
                 InstanceAddrSelectResult::ALL(self.instance_keys.clone())


### PR DESCRIPTION
## 关联 Issue

closes #20

## 改动说明

使用虚拟节点的一致性哈希环实现 `ConsistentHash` 路由策略，确保同一个 `job_id` 始终路由到同一个执行器实例。当执行器节点发生增减时，只有少量任务会被重新分配，最大程度减少迁移影响。

### 具体改动（`src/task/model/app_instance.rs`）

- 新增 `ConsistentHashRing` 结构体，基于 `BTreeMap<u64, Arc<String>>` 实现哈希环
- 每个实例节点分配 160 个虚拟节点，保证负载均匀分布
- 在 `AppInstanceStateGroup` 中维护 `hash_ring` 字段，实例增删时自动重建哈希环
- 替换原有简单取模实现为环形一致性哈希查找（顺时针查找最近节点）

### 路由行为

- 同一个 `job_id` 在执行器列表不变的情况下，始终路由到同一个执行器
- 执行器节点变更时，仅影响哈希环上相邻区间的任务分配，其余任务保持不变
