### PR TITLE
fix: 修复 k8s 挂载卷重启时 Actor started() 中 panic 的问题

### DIFF
--- a/src/app/core.rs
+++ b/src/app/core.rs
@@ -384,7 +384,9 @@ impl Actor for AppManager {
 
     fn started(&mut self, ctx: &mut Context<Self>) {
         log::info!("AppManager started");
-        self.heartbeat(ctx);
+        ctx.run_later(std::time::Duration::from_millis(500), |act, ctx| {
+            act.heartbeat(ctx);
+        });
     }
 }
 

--- a/src/cache/core.rs
+++ b/src/cache/core.rs
@@ -255,7 +255,9 @@ impl Actor for CacheManager {
 
     fn started(&mut self, ctx: &mut Self::Context) {
         log::info!("CacheManager actor started");
-        self.heartbeat(ctx);
+        ctx.run_later(std::time::Duration::from_millis(500), |act, ctx| {
+            act.heartbeat(ctx);
+        });
     }
 }
 


### PR DESCRIPTION
## 问题描述

修复 #17

k8s 挂载卷之后重启项目时，出现以下 panic：

```
thread 'main' panicked at .../actix-0.13.5/src/utils.rs:114:22:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
```

## 原因分析

`AppManager` 和 `CacheManager` 的 `Actor::started()` 方法中直接调用了 `self.heartbeat(ctx)`，而 `heartbeat()` 内部通过 `ctx.run_later()` 使用了 `tokio::time::sleep` 创建定时器。

当 Actor 在独立线程中通过 `System::new()` + `block_on()` 启动时（如 `create_actor_at_thread`），`started()` 在 actor context 初始化阶段被同步调用，此时 Tokio runtime 的 reactor 可能尚未完全就绪，导致 `sleep` 找不到 reactor 而 panic。

在 k8s 挂载卷场景下，由于文件系统 I/O 延迟，这个时序问题更容易被触发。

## 修复方式

将 `started()` 中的 `self.heartbeat(ctx)` 调用改为通过 `ctx.run_later()` 延迟 500ms 执行：

```rust
// 修改前
fn started(&mut self, ctx: &mut Context<Self>) {
    self.heartbeat(ctx);
}

// 修改后
fn started(&mut self, ctx: &mut Context<Self>) {
    ctx.run_later(std::time::Duration::from_millis(500), |act, ctx| {
        act.heartbeat(ctx);
    });
}
```

这样确保定时器的创建被推迟到 actor 事件循环正常运行之后，Tokio runtime 已完全初始化，避免 reactor 不存在的 panic。

## 影响范围

- `src/app/core.rs` — `AppManager::started()`
- `src/cache/core.rs` — `CacheManager::started()`